### PR TITLE
🐛 fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > use bash auto enable your sidecar
 
-### 🏠 [Homepage](github.com/fuergaosi233/enable-sidecar)
+### 🏠 [Homepage](https://github.com/fuergaosi233/enable-sidecar)
 
 ## Usage
 


### PR DESCRIPTION
Now the current link is https://github.com/fuergaosi233/enable-sidecar/blob/main/github.com/fuergaosi233/enable-sidecar , which is broken.